### PR TITLE
Symlinking on deploys & Rollback functionality

### DIFF
--- a/ansible/roles/glimesh-web/tasks/main.yml
+++ b/ansible/roles/glimesh-web/tasks/main.yml
@@ -82,17 +82,13 @@
     get_checksum: no
   register: current_deploy
 
-- name: Debug
-  debug:
-    var: current_deploy
-
 - name: Same version deployed?
   pause:
     prompt: |
       WARNING: Latest version is already deployed.
       Pess Enter to continue
   delegate_to: localhost
-  when: current_deploy.stat.lnk_target == deploy_dest
+  when: current_deploy.stat.exists and current_deploy.stat.lnk_target == deploy_dest
   register: same_deploy
 
 ## Build the deploy
@@ -103,7 +99,6 @@
     chdir: /tmp/glimesh.tv
   environment:
     MIX_ENV: prod
-  # when: glimesh.changed
 
 - name: install npm asset deps
   command: npm --prefix ./assets ci --progress=false --no-audit --loglevel=error
@@ -192,17 +187,31 @@
   pause:
     seconds: 15
 
+- name: Add a symlink to the old deploy for ease of rollback
+  file:
+    src: "{{ current_deploy.stat.lnk_target }}"
+    dest: /opt/glimesh.tv-old
+    state: link
+    owner: nobody
+    force: yes
+
 - name: Cleanup old directories
   block:
-    - name: Add a symlink to the old deploy for ease of rollback
-      file:
-        src: "{{ current_deploy.stat.lnk_target }}"
-        dest: /opt/glimesh.tv-old
-        state: link
-        owner: nobody
-        force: yes
+    - name: Get currently deployed dest
+      stat:
+        path: /opt/glimesh.tv
+        follow: no
+        get_checksum: no
+      register: gtv_current
 
-    ## Cleanup
+    - name: Get old deployed dest
+      stat:
+        path: /opt/glimesh.tv-old
+        follow: no
+        get_checksum: no
+      register: gtv_old
+
+    # Cleanup
     - name: Find all deploy folders
       find:
         paths: /opt
@@ -216,9 +225,11 @@
       file:
         path: "{{ item }}"
         state: absent
-      when: item != current_deploy.stat.lnk_target and item != deploy_dest
+      when:
+        - item != '/opt/glimesh.tv-old'
+        - gtv_current.stat.exists == False or item != gtv_current.stat.lnk_target
+        - gtv_old.stat.exists == False or item != gtv_old.stat.lnk_target
       with_items: "{{ all_deploys.files | map(attribute='path') | list }}"
 
-  when: same_deploy is not defined
   tags:
     - cleanup

--- a/ansible/roles/glimesh-web/tasks/main.yml
+++ b/ansible/roles/glimesh-web/tasks/main.yml
@@ -106,7 +106,7 @@
 
 - name: Ensure deploy state directories exist
   file:
-    path: /opt/glimesh.tv-{{ item }}
+    path: "/opt/glimesh.tv-{{ item }}"
     state: directory
     owner: nobody
     recurse: yes

--- a/ansible/roles/glimesh-web/tasks/main.yml
+++ b/ansible/roles/glimesh-web/tasks/main.yml
@@ -70,6 +70,29 @@
     regexp: '^\s+version: .*$'
     line: "version: \"0.1.0+{{ glimesh_git_hash.stdout }}\","
 
+- set_fact:
+    deploy_dest: "/opt/glimesh.tv-{{ glimesh_git_hash.stdout }}"
+
+## Check we should deploy
+
+- name: Get currently deployed hash
+  stat:
+    path: /opt/glimesh.tv
+    follow: yes
+    get_checksum: no
+  register: current_deploy
+
+- name: Same version deployed?
+  pause:
+    prompt: |
+      WARNING: Latest version is already deployed.
+      Pess Enter to continue
+  delegate_to: localhost
+  when: current_deploy.stat.lnk_target == deploy_dest
+  register: same_deploy
+
+## Build the deploy
+
 - name: install mix dependencies
   command: mix do deps.get, deps.compile
   args:
@@ -104,44 +127,28 @@
     MIX_ENV: prod
   # when: glimesh.changed
 
-- name: ensure opt host exists
+- name: Ensure new directory exists
   file:
-    path: /opt/glimesh.tv
-    state: directory
-    owner: nobody
-    mode: 0755
-
-- name: Ensure deploy state directories exist
-  file:
-    path: "/opt/glimesh.tv-{{ item }}"
+    path: "{{ deploy_dest }}"
     state: directory
     owner: nobody
     recurse: yes
-  with_items:
-    - "old"
-    - "new"
 
-- name: Copy currently live files to old directory
+- name: Copy newly built files to new host
   synchronize:
-    src: /opt/glimesh.tv
-    dest: /opt/glimesh.tv-old
+    src: /tmp/glimesh.tv
+    dest: "{{ deploy_dest }}"
     links: yes
     delete: yes
   delegate_to: "{{ inventory_hostname }}"
 
-- name: Copy newly built files to new store
-  synchronize:
-    src: /tmp/glimesh.tv/_build/prod
-    dest: /opt/glimesh.tv-new
-    links: yes
-    delete: yes
-  delegate_to: "{{ inventory_hostname }}"
-
-- name: permissions
+- name: Check permissions
   file:
-    path: /opt/glimesh.tv-new
+    path: "{{ deploy_dest }}"
     owner: nobody
     recurse: yes
+
+## Change the service
 
 - name: setup unit file for glimesh.tv
   template:
@@ -161,7 +168,7 @@
 
 - name: Change the symlink
   file:
-    src: /opt/glimesh.tv-new
+    src: "{{ deploy_dest }}"
     dest: /opt/glimesh.tv
     state: link
     owner: nobody
@@ -180,3 +187,34 @@
 - name: pause to make sure the other node can take over
   pause:
     seconds: 15
+
+- name: Cleanup old directories
+  block:
+    - name: Add a symlink to the old deploy for ease of rollback
+      file:
+        src: "{{ current_deploy.stat.lnk_target }}"
+        dest: /opt/glimesh.tv-old
+        state: link
+        owner: nobody
+        force: yes
+
+    ## Cleanup
+    - name: Find all deploy folders
+      find:
+        paths: /opt
+        file_type: directory
+        use_regex: yes
+        patterns: "^glimesh.tv-([a-zA-Z0-9]+)$"
+        recurse: no
+      register: all_deploys
+
+    - name: Delete old directories
+      file:
+        path: "{{ item }}"
+        state: absent
+        when: item != current_deploy.stat.lnk_target and item != deploy_dest
+      with_items: "{{ all_deploys.files | map(attribute='path') | list }}"
+
+  when: same_deploy is not defined
+  tags:
+    - cleanup

--- a/ansible/roles/glimesh-web/tasks/main.yml
+++ b/ansible/roles/glimesh-web/tasks/main.yml
@@ -5,15 +5,15 @@
     name: "{{ inventory_hostname }}"
 
 - name: Ensure .ssh directory exists.
-  file: 
+  file:
     dest: "/root/.ssh"
-    mode: 0700 
-    owner: root 
+    mode: 0700
+    owner: root
     state: directory
 
 - name: Install ssh key
-  copy: 
-    src: "glimesh-deploy" 
+  copy:
+    src: "glimesh-deploy"
     dest: "/root/.ssh/id_rsa"
     mode: 0600
     owner: root
@@ -27,12 +27,12 @@
 
 # - name: install required packages
 #   apt:
-#     pkg: 
-#       - esl-erlang 
-#       - elixir 
-#       - npm 
+#     pkg:
+#       - esl-erlang
+#       - elixir
+#       - npm
 #       - git
-#       - openssl 
+#       - openssl
 #       - imagemagick
 #     state: present
 #     update_cache: yes
@@ -43,8 +43,10 @@
 - name: install rebar
   command: mix local.rebar --force
 
-- name: ensure /tmp/glimesh.tv exists
-  file: path=/tmp/glimesh.tv state=directory
+- name: ensure web_build_dir exists
+  file:
+    path: /tmp/glimesh.tv
+    state: directory
 
 - name: download glimesh.tv
   git:
@@ -62,14 +64,14 @@
     chdir: /tmp/glimesh.tv
   register: glimesh_git_hash
 
-- name: change version 
+- name: change version
   lineinfile:
     path: /tmp/glimesh.tv/mix.exs
     regexp: '^\s+version: .*$'
     line: "version: \"0.1.0+{{ glimesh_git_hash.stdout }}\","
 
 - name: install mix dependencies
-  command: mix do deps.get, deps.compile 
+  command: mix do deps.get, deps.compile
   args:
     chdir: /tmp/glimesh.tv
   environment:
@@ -95,7 +97,7 @@
   # when: glimesh.changed
 
 - name: build glimesh.tv
-  command: mix do compile --force, release --force --overwrite 
+  command: mix do compile --force, release --force --overwrite
   args:
     chdir: /tmp/glimesh.tv
   environment:
@@ -103,7 +105,10 @@
   # when: glimesh.changed
 
 - name: setup unit file for glimesh.tv
-  template: src=glimesh.service.j2 dest=/etc/systemd/system/glimesh.service mode=644
+  template:
+    src: glimesh.service.j2
+    dest: /etc/systemd/system/glimesh.service
+    mode: 644
   tags: config
 
 - name: reload systemd immediately
@@ -111,22 +116,49 @@
     daemon_reload: yes
 
 - name: gracefully shut down old glimesh app
-  systemd: 
+  systemd:
     name: glimesh
     state: stopped
 
-# Copying the file will automatically restart the daemon.
-- name: copy built glimesh.tv
-  command: cp -Rf /tmp/glimesh.tv/_build/prod /opt/glimesh.tv 
+- name: Ensure deploy state directories exist
+  file:
+    path: /opt/glimesh.tv-{{ item }}
+    state: directory
+    owner: nobody
+    recurse: yes
+  with_items:
+    - "old"
+    - "new"
+
+- name: Copy currently live files to old directory
+  synchronize:
+    src: /opt/glimesh.tv
+    dest: /opt/glimesh.tv-old
+    links: yes
+
+# Shouldn't we rsync?
+- name: Copy newly built files to new store
+  synchronize:
+    src: /tmp/glimesh.tv/_build/prod
+    dest: /opt/glimesh.tv-new
+    links: yes
 
 - name: permissions
   file:
-    path: /opt/glimesh.tv
+    path: /opt/glimesh.tv-new
     owner: nobody
     recurse: yes
 
+- name: Change the symlink
+  file:
+    src: /opt/glimesh.tv-new
+    dest: /opt/glimesh.tv
+    state: link
+    owner: nobody
+    force: yes
+
 - name: start new glimesh app
-  systemd: 
+  systemd:
     name: glimesh
     state: started
 
@@ -136,5 +168,5 @@
     delay: 5
 
 - name: pause to make sure the other node can take over
-  pause: 
+  pause:
     seconds: 15

--- a/ansible/roles/glimesh-web/tasks/main.yml
+++ b/ansible/roles/glimesh-web/tasks/main.yml
@@ -140,7 +140,7 @@
 
 - name: Copy newly built files to new host
   synchronize:
-    src: /tmp/glimesh.tv
+    src: /tmp/glimesh.tv/_build/prod
     dest: "{{ deploy_dest }}"
     links: yes
     delete: yes

--- a/ansible/roles/glimesh-web/tasks/main.yml
+++ b/ansible/roles/glimesh-web/tasks/main.yml
@@ -43,7 +43,7 @@
 - name: install rebar
   command: mix local.rebar --force
 
-- name: ensure web_build_dir exists
+- name: ensure tmp build dir exists
   file:
     path: /tmp/glimesh.tv
     state: directory
@@ -103,6 +103,13 @@
   environment:
     MIX_ENV: prod
   # when: glimesh.changed
+
+- name: ensure opt host exists
+  file:
+    path: /opt/glimesh.tv
+    state: directory
+    owner: nobody
+    mode: 0755
 
 - name: Ensure deploy state directories exist
   file:

--- a/ansible/roles/glimesh-web/tasks/main.yml
+++ b/ansible/roles/glimesh-web/tasks/main.yml
@@ -78,9 +78,13 @@
 - name: Get currently deployed hash
   stat:
     path: /opt/glimesh.tv
-    follow: yes
+    follow: no
     get_checksum: no
   register: current_deploy
+
+- name: Debug
+  debug:
+    var: current_deploy
 
 - name: Same version deployed?
   pause:

--- a/ansible/roles/glimesh-web/tasks/main.yml
+++ b/ansible/roles/glimesh-web/tasks/main.yml
@@ -104,22 +104,6 @@
     MIX_ENV: prod
   # when: glimesh.changed
 
-- name: setup unit file for glimesh.tv
-  template:
-    src: glimesh.service.j2
-    dest: /etc/systemd/system/glimesh.service
-    mode: 644
-  tags: config
-
-- name: reload systemd immediately
-  systemd:
-    daemon_reload: yes
-
-- name: gracefully shut down old glimesh app
-  systemd:
-    name: glimesh
-    state: stopped
-
 - name: Ensure deploy state directories exist
   file:
     path: /opt/glimesh.tv-{{ item }}
@@ -148,6 +132,22 @@
     path: /opt/glimesh.tv-new
     owner: nobody
     recurse: yes
+
+- name: setup unit file for glimesh.tv
+  template:
+    src: glimesh.service.j2
+    dest: /etc/systemd/system/glimesh.service
+    mode: 644
+  tags: config
+
+- name: reload systemd immediately
+  systemd:
+    daemon_reload: yes
+
+- name: gracefully shut down old glimesh app
+  systemd:
+    name: glimesh
+    state: stopped
 
 - name: Change the symlink
   file:

--- a/ansible/roles/glimesh-web/tasks/main.yml
+++ b/ansible/roles/glimesh-web/tasks/main.yml
@@ -119,12 +119,16 @@
     src: /opt/glimesh.tv
     dest: /opt/glimesh.tv-old
     links: yes
+    delete: yes
+  delegate_to: "{{ inventory_hostname }}"
 
 - name: Copy newly built files to new store
   synchronize:
     src: /tmp/glimesh.tv/_build/prod
     dest: /opt/glimesh.tv-new
     links: yes
+    delete: yes
+  delegate_to: "{{ inventory_hostname }}"
 
 - name: permissions
   file:

--- a/ansible/roles/glimesh-web/tasks/main.yml
+++ b/ansible/roles/glimesh-web/tasks/main.yml
@@ -216,7 +216,7 @@
       file:
         path: "{{ item }}"
         state: absent
-        when: item != current_deploy.stat.lnk_target and item != deploy_dest
+      when: item != current_deploy.stat.lnk_target and item != deploy_dest
       with_items: "{{ all_deploys.files | map(attribute='path') | list }}"
 
   when: same_deploy is not defined

--- a/ansible/roles/glimesh-web/tasks/main.yml
+++ b/ansible/roles/glimesh-web/tasks/main.yml
@@ -120,7 +120,6 @@
     dest: /opt/glimesh.tv-old
     links: yes
 
-# Shouldn't we rsync?
 - name: Copy newly built files to new store
   synchronize:
     src: /tmp/glimesh.tv/_build/prod

--- a/ansible/web-rollback.yml
+++ b/ansible/web-rollback.yml
@@ -3,15 +3,22 @@
   serial: 1
 
   tasks:
+    - name: Get old deployed hash
+      stat:
+        path: /opt/glimesh.tv-old
+        follow: yes
+        get_checksum: no
+      register: old_deploy
+
     - name: Change the symlink
       file:
-        src: /opt/glimesh.tv-old
+        src: "{{ old_deploy.stat.lnk_target }}"
         dest: /opt/glimesh.tv
         state: link
         owner: nobody
         force: yes
 
-    - name: restarted glimesh
+    - name: restart glimesh
       systemd:
         name: glimesh
         daemon_reload: yes

--- a/ansible/web-rollback.yml
+++ b/ansible/web-rollback.yml
@@ -1,0 +1,27 @@
+- name: web
+  hosts: web
+  serial: 1
+
+  tasks:
+    - name: Change the symlink
+      file:
+        src: /opt/glimesh.tv-old
+        dest: /opt/glimesh.tv
+        state: link
+        owner: nobody
+        force: yes
+
+    - name: restarted glimesh
+      systemd:
+        name: glimesh
+        daemon_reload: yes
+        state: restarted
+
+    - name: wait for service to be online
+      wait_for:
+        port: 8080
+        delay: 5
+
+    - name: pause to make sure the other node can take over
+      pause:
+        seconds: 15

--- a/ansible/web-rollback.yml
+++ b/ansible/web-rollback.yml
@@ -6,7 +6,7 @@
     - name: Get old deployed hash
       stat:
         path: /opt/glimesh.tv-old
-        follow: yes
+        follow: no
         get_checksum: no
       register: old_deploy
 


### PR DESCRIPTION
My IDE also removes tailing spaces, which ansible-lint also classifies as an invalid thing

Anyway.

Changes:
 - Adds 3 states of the web: new, current (symlinked to new), old
 - Reduces downtime by moving service stop to last possible moment, right before the symlink
 - Adds Rollback functionality & new playbook to do so

Tests:
Ideally, this would be tested on a real server, but I don't think that's possible?

Issues fixed:
https://github.com/Glimesh/ops/issues/7
https://github.com/Glimesh/ops/issues/3