### PR TITLE
Add blackbox_exporter for ftl_edge

### DIFF
--- a/ansible/roles/monitor/defaults/main.yml
+++ b/ansible/roles/monitor/defaults/main.yml
@@ -4,3 +4,6 @@ prometheus_service_name: prometheus
 prometheus_user_name: prometheus
 prometheus_group_name: prometheus
 prometheus_version: "2.23.0"
+
+blackbox_exporter_service_name: blackbox_exporter
+blackbox_exporter_version: "0.18.0"

--- a/ansible/roles/monitor/handlers/main.yml
+++ b/ansible/roles/monitor/handlers/main.yml
@@ -12,3 +12,8 @@
   systemd:
     name: prometheus
     state: restarted
+
+- name: restart blackbox_exporter
+  systemd:
+    name: blackbox_exporter
+    state: restarted

--- a/ansible/roles/monitor/tasks/blackbox_exporter.yml
+++ b/ansible/roles/monitor/tasks/blackbox_exporter.yml
@@ -1,0 +1,48 @@
+---
+
+- name: Install Blackbox Exporter for Prometheus
+  unarchive:
+    src: "https://github.com/prometheus/blackbox_exporter/releases/download/v{{ blackbox_exporter_version }}/blackbox_exporter-{{ blackbox_exporter_version }}.linux-amd64.tar.gz"
+    dest: /tmp/
+    remote_src: yes
+
+- name: Copy blackbox_exporter to bin
+  copy:
+    src: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-amd64/blackbox_exporter"
+    dest: "/usr/local/bin/blackbox_exporter"
+    owner: "{{ prometheus_user_name }}"
+    group: "{{ prometheus_group_name }}"
+    remote_src: yes
+    mode: 0755
+
+- name: Delete blackbox_exporter tmp folder
+  file:
+    path: "/tmp/blackbox_exporter-{{ blackbox_exporter_version }}.linux-amd64"
+    state: absent
+
+- name: Create Config directory
+  file:
+    path: "/etc/blackbox_exporter/"
+    state: directory
+    owner: "{{ prometheus_user_name }}"
+    group: "{{ prometheus_group_name }}"
+    mode: 0755
+
+- name: config file
+  template:
+    src: blackbox_exporter.conf.j2
+    dest: /etc/blackbox_exporter/blackbox_exporter.conf
+
+- name: Create Unit file for blackbox_exporter
+  template: src=blackbox_exporter.service.j2 dest=/etc/systemd/system/blackbox_exporter.service mode=644
+  notify:
+    - reload systemctl
+
+- name: start blackbox_exporter service
+  service: name=blackbox_exporter.service state=restarted enabled=yes
+
+- name: Check if blackbox_exporter is accessible
+  uri:
+    url: http://localhost:9115
+    method: GET
+    status_code: 200

--- a/ansible/roles/monitor/tasks/main.yml
+++ b/ansible/roles/monitor/tasks/main.yml
@@ -6,3 +6,4 @@
 
 - include: grafana.yml
 - include: prometheus.yml
+- include: blackbox_exporter.yml

--- a/ansible/roles/monitor/templates/blackbox_exporter.conf.j2
+++ b/ansible/roles/monitor/templates/blackbox_exporter.conf.j2
@@ -1,0 +1,30 @@
+modules:
+
+  http_2xx:
+    prober: http
+
+  http_json_200:
+    timeout: 5s
+    prober: http
+    http:
+      valid_status_codes: [200]
+      method: GET
+      # Don't follow redirect
+      no_follow_redirects: true
+      headers:
+        Accept: "application/json"
+      fail_if_header_not_matches:
+        - header: "Content-Type"
+          regexp: "application/json"
+
+  tcp_connect:
+    prober: tcp
+
+  ssh_banner:
+    prober: tcp
+    tcp:
+      query_response:
+      - expect: "^SSH-2.0-"
+
+  icmp:
+    prober: icmp

--- a/ansible/roles/monitor/templates/blackbox_exporter.service.j2
+++ b/ansible/roles/monitor/templates/blackbox_exporter.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description={{ blackbox_exporter_service_name }}
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User={{ prometheus_user_name }}
+Group={{ prometheus_group_name }}
+Restart=on-abnormal
+Type=simple
+ExecStart=/usr/local/bin/blackbox_exporter --config.file=/etc/blackbox_exporter/blackbox_exporter.conf --web.listen-address="localhost:9115"
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/monitor/templates/prometheus.conf.j2
+++ b/ansible/roles/monitor/templates/prometheus.conf.j2
@@ -16,7 +16,28 @@ scrape_configs:
 {% for host in groups['node_exporter'] %}
 {% if inventory_hostname != host %}
       - targets: ['{{ host }}:9100']
-        labels: 
+        labels:
+          region: {{ hostvars[host].region }}
+          ftl_node_kind: {{ hostvars[host].ftl_node_kind }}
+{% endif %}
+{% endfor %}
+  - job_name: 'janus_http'
+    scrape_interval: 5s
+    metrics_path: /probe
+    params:
+      module: [http_json_200]  # Look for a HTTP 200 with JSON data
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: localhost:9115  # The blackbox exporter's real hostname:port.
+    static_configs:
+{% for host in groups['ftl_edge'] %}
+{% if inventory_hostname != host %}
+      - targets: ['https://{{ host }}/janus/info']
+        labels:
           region: {{ hostvars[host].region }}
           ftl_node_kind: {{ hostvars[host].ftl_node_kind }}
 {% endif %}


### PR DESCRIPTION
* Uses existing prometheus user/group
* Only installs the exporter on monitor node, that is then querying each FTL edge
* FTL Ingests aren't presenting API publicly, thus not included in targets
* Labelling will be eg. `instance=https://do-ams3-edge1.eham.live.glimesh.tv/janus/info` 🤷‍♂️ 
* [FUTURE] Could potentially add ICMP in future, or even each FTL has a blackbox exporter and is then querying every other FTL node - could then build understanding of internode latencies
* [FUTURE] the blackbox exporter supports [basic query/response checks via TCP](https://github.com/prometheus/blackbox_exporter/blob/b57ed98f35ac992d039628165cb6a177b9830839/example.yml#L63-L97) - can this further query FTL?


Other DNS / HTTP checks against other services?