### PR TITLE
Blackbox FTL ping

### DIFF
--- a/ansible/roles/monitor/templates/blackbox_exporter.conf.j2
+++ b/ansible/roles/monitor/templates/blackbox_exporter.conf.j2
@@ -17,6 +17,14 @@ modules:
         - header: "Content-Type"
           regexp: "application/json"
 
+  ftl_ping:
+    timeout: 5s
+    prober: tcp
+    tcp:
+      query_response:
+        - send: "PING\r\n\r\n"
+        - expect: "^201$"
+
   tcp_connect:
     prober: tcp
 
@@ -24,7 +32,7 @@ modules:
     prober: tcp
     tcp:
       query_response:
-      - expect: "^SSH-2.0-"
+        - expect: "^SSH-2.0-"
 
   icmp:
     prober: icmp

--- a/ansible/roles/monitor/templates/prometheus.conf.j2
+++ b/ansible/roles/monitor/templates/prometheus.conf.j2
@@ -10,6 +10,7 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
       - targets: ['localhost:9090']
+
   - job_name: 'node_exporter'
     scrape_interval: 5s
     static_configs:
@@ -21,6 +22,7 @@ scrape_configs:
           ftl_node_kind: {{ hostvars[host].ftl_node_kind }}
 {% endif %}
 {% endfor %}
+
   - job_name: 'janus_http'
     scrape_interval: 5s
     metrics_path: /probe
@@ -37,6 +39,29 @@ scrape_configs:
 {% for host in groups['ftl_edge'] %}
 {% if inventory_hostname != host %}
       - targets: ['https://{{ host }}/janus/info']
+        labels:
+          region: {{ hostvars[host].region }}
+          ftl_node_kind: {{ hostvars[host].ftl_node_kind }}
+{% endif %}
+{% endfor %}
+
+
+  - job_name: 'janus_ftl_ping'
+    scrape_interval: 5s
+    metrics_path: /probe
+    params:
+      module: [ftl_ping]  # Look for a 201 response to a PING
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: localhost:9115  # The blackbox exporter's real hostname:port.
+    static_configs:
+{% for host in (groups['ftl_ingest'] + groups['ftl_edge']) %}
+{% if inventory_hostname != host %}
+      - targets: ['{{ host }}:8084']
         labels:
           region: {{ hostvars[host].region }}
           ftl_node_kind: {{ hostvars[host].ftl_node_kind }}


### PR DESCRIPTION
* Adds a Prometheus job to run the FTL Ping against each FTL node


Looks good testing via `/probe?target=ingest.egll.live.glimesh.tv:8084&module=ftl_ping&debug=true`
```
ts=2021-03-04T17:08:47.845302Z caller=main.go:304 module=ftl_ping target=ingest.egll.live.glimesh.tv:8084 level=info msg="Beginning probe" probe=tcp timeout_seconds=5
ts=2021-03-04T17:08:47.845448Z caller=tcp.go:41 module=ftl_ping target=ingest.egll.live.glimesh.tv:8084 level=info msg="Resolving target address" ip_protocol=ip6
ts=2021-03-04T17:08:47.848592Z caller=tcp.go:41 module=ftl_ping target=ingest.egll.live.glimesh.tv:8084 level=info msg="Resolved target address" ip=46.101.47.73
ts=2021-03-04T17:08:47.848659Z caller=tcp.go:122 module=ftl_ping target=ingest.egll.live.glimesh.tv:8084 level=info msg="Dialing TCP without TLS"
ts=2021-03-04T17:08:47.865042Z caller=main.go:119 module=ftl_ping target=ingest.egll.live.glimesh.tv:8084 level=info msg="Successfully dialed"
ts=2021-03-04T17:08:47.865075Z caller=main.go:119 module=ftl_ping target=ingest.egll.live.glimesh.tv:8084 level=info msg="Processing query response entry" entry_number=0
ts=2021-03-04T17:08:47.865086Z caller=main.go:119 module=ftl_ping target=ingest.egll.live.glimesh.tv:8084 level=debug msg="Sending line" line="PING\r\n\r\n"
ts=2021-03-04T17:08:47.865115Z caller=main.go:119 module=ftl_ping target=ingest.egll.live.glimesh.tv:8084 level=info msg="Processing query response entry" entry_number=1
ts=2021-03-04T17:08:47.881072Z caller=main.go:119 module=ftl_ping target=ingest.egll.live.glimesh.tv:8084 level=debug msg="Read line" line=201
ts=2021-03-04T17:08:47.881145Z caller=main.go:119 module=ftl_ping target=ingest.egll.live.glimesh.tv:8084 level=info msg="Regexp matched" regexp=^201$ line=201
ts=2021-03-04T17:08:47.881255Z caller=main.go:304 module=ftl_ping target=ingest.egll.live.glimesh.tv:8084 level=info msg="Probe succeeded" duration_seconds=0.035900446
```


Not many metrics from a TCP probe 🤷‍♂️  `probe_success` and maybe latency ?

```
Metrics that would have been returned:
# HELP probe_dns_lookup_time_seconds Returns the time taken for probe dns lookup in seconds
# TYPE probe_dns_lookup_time_seconds gauge
probe_dns_lookup_time_seconds 0.003187859

# HELP probe_duration_seconds Returns how long the probe took to complete in seconds
# TYPE probe_duration_seconds gauge
probe_duration_seconds 0.035900446

# HELP probe_failed_due_to_regex Indicates if probe failed due to regex
# TYPE probe_failed_due_to_regex gauge
probe_failed_due_to_regex 0

# HELP probe_ip_addr_hash Specifies the hash of IP address. It's useful to detect if the IP address changes.
# TYPE probe_ip_addr_hash gauge
probe_ip_addr_hash 2.029185824e+09

# HELP probe_ip_protocol Specifies whether probe ip protocol is IP4 or IP6
# TYPE probe_ip_protocol gauge
probe_ip_protocol 4

# HELP probe_success Displays whether or not the probe was a success
# TYPE probe_success gauge
probe_success 1
```