### PR TITLE
Janus FTL - sd_notify support

### DIFF
--- a/ansible/roles/janus-ftl-plugin/templates/janus.service.j2
+++ b/ansible/roles/janus-ftl-plugin/templates/janus.service.j2
@@ -6,8 +6,14 @@ After=syslog.target network.target
 [Service]
 User=root
 Nice=1
+Type=notify
 Restart=on-abnormal
 RestartSec=10
+# How long systemd will wait for the service to signal "start-up completion"
+TimeoutStartSec=30s
+# Max time systemd will wait between service keepalive pings
+WatchdogSec=10s
+NotifyAccess=exec
 LimitNOFILE=65536
 ExecStart=/opt/janus/bin/janus -o
 

--- a/ansible/roles/janus-ftl-plugin/templates/janus.service.j2
+++ b/ansible/roles/janus-ftl-plugin/templates/janus.service.j2
@@ -7,15 +7,18 @@ After=syslog.target network.target
 User=root
 Nice=1
 Type=notify
-Restart=on-abnormal
+Restart=on-failure
 RestartSec=10
 # How long systemd will wait for the service to signal "start-up completion"
 TimeoutStartSec=30s
 # Max time systemd will wait between service keepalive pings
-WatchdogSec=10s
+WatchdogSec=60s
 NotifyAccess=exec
 LimitNOFILE=65536
 ExecStart=/opt/janus/bin/janus -o
+StartLimitInterval=5min
+StartLimitBurst=4
+StartLimitAction=reboot-force
 
 Environment="FTL_NODE_KIND={{ ftl_node_kind }}"
 


### PR DESCRIPTION
Rough changes to the FTL `systemd` unit file to use the soon to be added (?) `sd_notify` support.

* Requires https://github.com/Glimesh/janus-ftl-plugin/commit/24d1d706863510e52cbe3feceff7954b219db3be

Will need testing, ~~this PR is also relying on the READY state being sent so it know whether to restart/retry which is not added in the above commit.~~ _this was later added_

https://www.freedesktop.org/software/systemd/man/systemd.service.html

Updated per https://github.com/Glimesh/janus-ftl-plugin/pull/99