### PR TITLE
Add monitor node_exporter config

### DIFF
--- a/ansible/hosts.example
+++ b/ansible/hosts.example
@@ -30,6 +30,7 @@ some-orchestrator-server
 monitoring-server
 
 [node_exporter:children]
+monitor
 ftl
 
 [all:vars]

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,24 +1,24 @@
 
-- name: web 
+- name: web
   hosts: web
   serial: 1
   roles:
     - glimesh-web
     - prometheus-node-exporter
 
-- name: ftl orchestrator 
+- name: ftl orchestrator
   hosts: ftl_orchestrator
   roles:
     - janus-ftl-orchestrator
     - prometheus-node-exporter
 
-- name: ftl ingest 
+- name: ftl ingest
   hosts: ftl_ingest
   roles:
     - janus-ftl-plugin
     - prometheus-node-exporter
 
-- name: ftl edge 
+- name: ftl edge
   hosts: ftl_edge
   vars:
     ftl_node_kind: edge
@@ -27,7 +27,8 @@
     - janus-ftl-nginx-ssl
     - prometheus-node-exporter
 
-- name: monitoring server 
+- name: monitoring server
   hosts: monitor
   roles:
     - monitor
+    - prometheus-node-exporter

--- a/ansible/roles/monitor/templates/prometheus.conf.j2
+++ b/ansible/roles/monitor/templates/prometheus.conf.j2
@@ -15,10 +15,10 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
 {% for host in groups['node_exporter'] %}
-{% if inventory_hostname != host %}
       - targets: ['{{ host }}:9100']
         labels:
           region: {{ hostvars[host].region }}
+{%- if hostvars[host].ftl_node_kind is defined %}
           ftl_node_kind: {{ hostvars[host].ftl_node_kind }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
* Adds node_exporter to monitoring node. Might help diagnose some monitoring blips we see - is the machine overloaded etc.
* Untested as always, that's my style
* I'm assuming your region var is defined somewhere for each node?
* Added logic to detect the FTL flag and label only when set