### PR TITLE
Install libsystemd-dev for janus-ftl-plugin role

### DIFF
--- a/ansible/roles/janus-ftl-plugin/tasks/main.yml
+++ b/ansible/roles/janus-ftl-plugin/tasks/main.yml
@@ -17,6 +17,7 @@
       - libcurl4-openssl-dev 
       - liblua5.3-dev 
       - libconfig-dev 
+      - libsystemd-dev
       - pkg-config 
       - gengetopt 
       - libtool 


### PR DESCRIPTION
This on it's own will not cause any behavior change.

But by doing this janus-ftl-plugin will build with systemd watchdog integration, which can be enabled by setting the systemd options outlined in the PR here: https://github.com/Glimesh/janus-ftl-plugin/pull/99

It'd be nice to get this in early, so when we decide to try out the systemd integration the build will already have it compiled-in.