### PR TITLE
Caddy: Grafana + Prometheus behind auto HTTPS

### DIFF
--- a/ansible/roles/caddy/files/default.conf
+++ b/ansible/roles/caddy/files/default.conf
@@ -1,0 +1,18 @@
+# Some sane defaults we can reuse
+(default_settings) {
+        # Enable GZIP. Caddy 2.4.0 will have some improvements to be made here
+        encode zstd gzip
+        log {
+                output stderr
+                format filter {
+                        wrap json
+                        fields {
+                                # Remove some sensitve headers from the logging
+                                request>headers>Authorization delete
+                                request>headers>Cookie delete
+                                response>headers>Set-Cookie delete
+                        }
+
+                }
+        }
+}

--- a/ansible/roles/caddy/files/secure.conf
+++ b/ansible/roles/caddy/files/secure.conf
@@ -15,5 +15,8 @@
 
         # Enable cross-site filter (XSS) and tell browser to block detected attacks
         X-XSS-Protection "1; mode=block"
+
+        # Perform the headers changes at the end of the request processing to avoid double headers
+        defer
     }
 }

--- a/ansible/roles/caddy/tasks/install.yml
+++ b/ansible/roles/caddy/tasks/install.yml
@@ -82,7 +82,7 @@
     method: GET
   register: _result
   until: _result.status == 204
-  retries: 12 # 12 * 5 seconds = 1 minute
+  retries: 36 # 36 * 5 seconds = 3 minutes
   delay: 5 # Every 5 seconds
   when: create_hostname_site and not acme_staging
 

--- a/ansible/roles/caddy/tasks/install.yml
+++ b/ansible/roles/caddy/tasks/install.yml
@@ -45,6 +45,7 @@
     mode: 0644
   with_items:
     - secure.conf
+    - default.conf
   notify:
     - validate caddy config
     - restart caddy

--- a/ansible/roles/caddy/templates/Caddyfile.j2
+++ b/ansible/roles/caddy/templates/Caddyfile.j2
@@ -9,14 +9,6 @@
         cert_issuer zerossl
 }
 
-# Some sane defaults we can reuse
-(default_settings) {
-        encode zstd gzip
-        log {
-                output stderr
-        }
-}
-
 # Load in any extra configured sites
 import {{ caddy_snippets_dir }}/*.conf
 import {{ caddy_sites_dir }}/*.conf

--- a/ansible/roles/monitor/tasks/grafana.yml
+++ b/ansible/roles/monitor/tasks/grafana.yml
@@ -23,3 +23,20 @@
     url: http://{{ inventory_hostname }}:3000
     method: GET
     status_code: 200
+
+- name: configure caddy for grafana
+  include_role:
+    name: caddy
+    apply:
+      tags:
+        - caddy
+    tasks_from: add_site
+    public: no
+  vars:
+    t_caddy_site_name: grafana
+    t_caddy_site_host: "grafana.{{ inventory_hostname }}"
+    t_caddy_site_default_settings: true
+    t_caddy_site_secure_headers: true
+    t_caddy_site_reverse_proxy: "localhost:3000"
+  tags:
+    - caddy

--- a/ansible/roles/monitor/tasks/prometheus.yml
+++ b/ansible/roles/monitor/tasks/prometheus.yml
@@ -118,3 +118,20 @@
     t_grafana_dashboard_is_default: true
   tags:
     - grafana
+
+- name: configure caddy for prometheus
+  include_role:
+    name: caddy
+    apply:
+      tags:
+        - caddy
+    tasks_from: add_site
+    public: no
+  vars:
+    t_caddy_site_name: prometheus
+    t_caddy_site_host: "prometheus.{{ inventory_hostname }}"
+    t_caddy_site_default_settings: true
+    t_caddy_site_secure_headers: true
+    t_caddy_site_reverse_proxy: "localhost:9090"
+  tags:
+    - caddy

--- a/terraform/monitor.tf
+++ b/terraform/monitor.tf
@@ -20,9 +20,15 @@ resource "digitalocean_droplet" "monitor" {
 }
 
 resource "cloudflare_record" "monitor_record" {
+    for_each = toset([
+    "",
+    "prometheus.",
+    "grafana.",
+  ])
+
   zone_id = lookup(data.cloudflare_zones.glimesh_domain_zones.zones[0], "id")
   type    = "A"
-  name    = var.monitor_hostname
+  name    = "${each.value}${var.monitor_hostname}"
   value   = digitalocean_droplet.monitor.ipv4_address
   proxied = false
 }


### PR DESCRIPTION
* Adds Caddy configs for Grafana + Prometheus (they call the add_site task in the Caddy role)
* Auto HTTPS via Caddy (as long as appropriate DNS exists for the configs)
* Updates Terraform to add the needed records (in future we can add promtail/loki etc.)
* Caddy logging is fairly verbose, so filtered out some fields we don't want logged


```
ansible-playbook -i hosts playbook.yml -l monitor -t caddy
```


Resolves #23. Future changes will look at limiting direct access to them and GitHub auth