### PR TITLE
Add Loki and Promtail to monitor server

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -32,4 +32,6 @@
   roles:
     - caddy
     - monitor
+    - loki
+    - promtail
     - prometheus-node-exporter

--- a/ansible/roles/loki/defaults/main.yml
+++ b/ansible/roles/loki/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+
+local_bin_path: "/usr/local/bin"
+
+loki_service_name: loki
+loki_user_name: loki
+loki_group_name: loki
+loki_version: "2.2.1"
+loki_force_install: false
+
+loki_caddy_site: true

--- a/ansible/roles/loki/defaults/main.yml
+++ b/ansible/roles/loki/defaults/main.yml
@@ -8,4 +8,4 @@ loki_group_name: loki
 loki_version: "2.2.1"
 loki_force_install: false
 
-loki_caddy_site: true
+loki_caddy_site: false

--- a/ansible/roles/loki/handlers/main.yml
+++ b/ansible/roles/loki/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: restart loki
+  systemd:
+    name: loki
+    daemon_reload: yes
+    state: restarted

--- a/ansible/roles/loki/tasks/install.yml
+++ b/ansible/roles/loki/tasks/install.yml
@@ -1,0 +1,116 @@
+---
+
+- name: install required loki packages
+  apt:
+    pkg:
+      - unzip
+    state: present
+    update_cache: yes
+
+- name: Creating loki group
+  group:
+    name: "{{ loki_group_name }}"
+    system: yes
+
+- name: Creating loki user
+  user:
+    name: "{{ loki_user_name }}"
+    group: "{{ loki_group_name }}"
+    system: yes
+    shell: "/sbin/nologin"
+    comment: "{{ loki_user_name }} nologin User"
+    createhome: no
+    home: "/data/loki/"
+
+- name: Creates loki data directory
+  file:
+    path: "/data/loki/"
+    state: directory
+    owner: "{{ loki_user_name }}"
+    group: "{{ loki_group_name }}"
+    mode: 0755
+
+- name: Creates loki config directory
+  file:
+    path: "/etc/loki/"
+    state: directory
+    owner: root
+    group: "{{ loki_group_name }}"
+    mode: 0770
+
+- name: Get current loki version
+  command: "{{ local_bin_path }}/loki -version"
+  check_mode: no
+  changed_when: false
+  failed_when: false
+  register: __loki_version
+
+- name: Determine whether we need to install loki
+  set_fact:
+    # if the version command failed, OR the parsed version did not match, then we install
+    _install_loki: "{% if __loki_version.rc != 0 or __loki_version.stdout_lines[0].split(' ')[2] != loki_version %}true{% else %}false{% endif %}"
+
+- name: Install loki
+  when: _install_loki or loki_force_install
+  block:
+    - name: Download loki
+      become: no
+      unarchive:
+        src: "https://github.com/grafana/loki/releases/download/v{{ loki_version }}/loki-linux-amd64.zip"
+        dest: /tmp/
+        remote_src: yes
+
+    - name: Copy loki file to bin
+      # Skip this when in --check mode as the download would have been skipped
+      when: not ansible_check_mode
+      copy:
+        src: "/tmp/loki-linux-amd64"
+        dest: "{{ local_bin_path }}/loki"
+        owner: "{{ loki_user_name }}"
+        group: "{{ loki_group_name }}"
+        remote_src: yes
+        mode: 0755
+      notify:
+        - restart loki
+
+- name: loki config file
+  template:
+    src: loki.yaml.j2
+    dest: /etc/loki/loki.yaml
+  notify:
+    - restart loki
+
+- name: Create Unit file for loki
+  template: src=loki.service.j2 dest=/etc/systemd/system/loki.service mode=644
+  notify:
+    - restart loki
+
+# Trigger systemctl reload/restart if needed
+- name: Flush handlers
+  meta: flush_handlers
+
+- name: start loki service
+  service: name=loki.service state=started enabled=yes
+
+- name: Check if loki is accessible
+  uri:
+    url: http://localhost:3100/metrics
+    method: GET
+    status_code: 200
+
+- name: configure caddy for Loki
+  include_role:
+    name: caddy
+    apply:
+      tags:
+        - caddy
+    tasks_from: add_site
+    public: no
+  vars:
+    t_caddy_site_name: loki
+    t_caddy_site_host: "loki.{{ inventory_hostname }}"
+    t_caddy_site_default_settings: true
+    t_caddy_site_secure_headers: true
+    t_caddy_site_reverse_proxy: "localhost:3100"
+  tags:
+    - caddy

--- a/ansible/roles/loki/tasks/install.yml
+++ b/ansible/roles/loki/tasks/install.yml
@@ -28,7 +28,7 @@
     state: directory
     owner: "{{ loki_user_name }}"
     group: "{{ loki_group_name }}"
-    mode: 0755
+    mode: 0750
 
 - name: Creates loki config directory
   file:
@@ -66,10 +66,10 @@
       copy:
         src: "/tmp/loki-linux-amd64"
         dest: "{{ local_bin_path }}/loki"
-        owner: "{{ loki_user_name }}"
+        owner: root
         group: "{{ loki_group_name }}"
         remote_src: yes
-        mode: 0755
+        mode: 0750
       notify:
         - restart loki
 
@@ -77,6 +77,9 @@
   template:
     src: loki.yaml.j2
     dest: /etc/loki/loki.yaml
+    owner: root
+    group: "{{ loki_group_name }}"
+    mode: 0640
   notify:
     - restart loki
 
@@ -98,7 +101,7 @@
     method: GET
     status_code: 200
 
-- name: configure caddy for Loki
+- name: configure caddy for loki
   include_role:
     name: caddy
     apply:
@@ -114,3 +117,19 @@
     t_caddy_site_reverse_proxy: "localhost:3100"
   tags:
     - caddy
+
+- name: configure grafana for loki
+  include_role:
+    name: monitor
+    apply:
+      tags:
+        - grafana
+    tasks_from: grafana_add_datasource
+    public: no
+  vars:
+    t_grafana_dashboard_name: Loki
+    t_grafana_dashboard_type: loki
+    t_grafana_dashboard_url: "http://localhost:3100"
+    t_grafana_dashboard_uid: "glim-loki"
+  tags:
+    - grafana

--- a/ansible/roles/loki/tasks/install.yml
+++ b/ansible/roles/loki/tasks/install.yml
@@ -115,6 +115,7 @@
     t_caddy_site_default_settings: true
     t_caddy_site_secure_headers: true
     t_caddy_site_reverse_proxy: "localhost:3100"
+  when: loki_caddy_site
   tags:
     - caddy
 

--- a/ansible/roles/loki/tasks/main.yml
+++ b/ansible/roles/loki/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- include: install.yml
+  become: yes
+  tags:
+    - loki

--- a/ansible/roles/loki/templates/loki.service.j2
+++ b/ansible/roles/loki/templates/loki.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description={{ loki_service_name }}
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User={{ loki_user_name }}
+Group={{ loki_group_name }}
+Restart=on-abnormal
+Type=simple
+ExecStart=/usr/local/bin/loki --config.file=/etc/loki/loki.yaml
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/loki/templates/loki.yaml.j2
+++ b/ansible/roles/loki/templates/loki.yaml.j2
@@ -1,0 +1,68 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+ingester:
+  wal:
+    enabled: true
+    dir: /tmp/wal
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 1h       # Any chunk not receiving new logs in this time will be flushed
+  max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
+  chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
+  chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
+  max_transfer_retries: 0     # Chunk transfers disabled
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /tmp/loki/boltdb-shipper-active
+    cache_location: /tmp/loki/boltdb-shipper-cache
+    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    shared_store: filesystem
+  filesystem:
+    directory: /tmp/loki/chunks
+
+compactor:
+  working_directory: /tmp/loki/boltdb-shipper-compactor
+  shared_store: filesystem
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+chunk_store_config:
+  max_look_back_period: 0s
+
+table_manager:
+  retention_deletes_enabled: false
+  retention_period: 0s
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /tmp/loki/rules
+  rule_path: /tmp/loki/rules-temp
+  alertmanager_url: http://localhost:9093
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true

--- a/ansible/roles/loki/templates/loki.yaml.j2
+++ b/ansible/roles/loki/templates/loki.yaml.j2
@@ -17,7 +17,7 @@ ingester:
     final_sleep: 0s
   chunk_idle_period: 1h       # Any chunk not receiving new logs in this time will be flushed
   max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
-  chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
+  chunk_target_size: 1536000  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
   chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
   max_transfer_retries: 0     # Chunk transfers disabled
 

--- a/ansible/roles/loki/templates/loki.yaml.j2
+++ b/ansible/roles/loki/templates/loki.yaml.j2
@@ -7,7 +7,7 @@ server:
 ingester:
   wal:
     enabled: true
-    dir: /tmp/wal
+    dir: /data/loki/wal
   lifecycler:
     address: 127.0.0.1
     ring:
@@ -33,15 +33,15 @@ schema_config:
 
 storage_config:
   boltdb_shipper:
-    active_index_directory: /tmp/loki/boltdb-shipper-active
-    cache_location: /tmp/loki/boltdb-shipper-cache
+    active_index_directory: /data/loki/boltdb-shipper-active
+    cache_location: /data/loki/boltdb-shipper-cache
     cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
     shared_store: filesystem
   filesystem:
-    directory: /tmp/loki/chunks
+    directory: /data/loki/chunks
 
 compactor:
-  working_directory: /tmp/loki/boltdb-shipper-compactor
+  working_directory: /data/loki/boltdb-shipper-compactor
   shared_store: filesystem
 
 limits_config:
@@ -59,8 +59,8 @@ ruler:
   storage:
     type: local
     local:
-      directory: /tmp/loki/rules
-  rule_path: /tmp/loki/rules-temp
+      directory: /data/loki/rules
+  rule_path: /data/loki/rules-temp
   alertmanager_url: http://localhost:9093
   ring:
     kvstore:

--- a/ansible/roles/loki/templates/loki.yaml.j2
+++ b/ansible/roles/loki/templates/loki.yaml.j2
@@ -1,8 +1,12 @@
 auth_enabled: false
 
 server:
+  # Random port is chosen when 0
+  http_listen_address: localhost
   http_listen_port: 3100
-  grpc_listen_port: 9096
+  grpc_listen_address: localhost
+  #grpc_listen_port: 9096
+  grpc_listen_port: 0
 
 ingester:
   wal:

--- a/ansible/roles/monitor/templates/prometheus.conf.j2
+++ b/ansible/roles/monitor/templates/prometheus.conf.j2
@@ -7,9 +7,44 @@ rule_files:
 
 scrape_configs:
   - job_name: 'prometheus'
-    scrape_interval: 5s
+    #scrape_interval: 5s
     static_configs:
       - targets: ['localhost:9090']
+        labels:
+          app: prometheus
+          instance: {{ inventory_hostname }}
+
+  - job_name: 'grafana-server'
+    #scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:3000']
+        labels:
+          app: grafana-server
+          instance: {{ inventory_hostname }}
+
+  - job_name: 'loki'
+    #scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:3100']
+        labels:
+          app: loki
+          instance: {{ inventory_hostname }}
+
+  - job_name: 'promtail'
+    #scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:9080']
+        labels:
+          app: promtail
+          instance: {{ inventory_hostname }}
+
+  - job_name: 'caddy'
+    #scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:2019']
+        labels:
+          app: caddy
+          instance: {{ inventory_hostname }}
 
   - job_name: 'node_exporter'
     scrape_interval: 5s

--- a/ansible/roles/promtail/defaults/main.yml
+++ b/ansible/roles/promtail/defaults/main.yml
@@ -6,4 +6,4 @@ promtail_service_name: promtail
 promtail_version: "2.2.1"
 promtail_force_install: false
 
-promtail_caddy_site: true
+promtail_caddy_site: false

--- a/ansible/roles/promtail/defaults/main.yml
+++ b/ansible/roles/promtail/defaults/main.yml
@@ -3,8 +3,6 @@
 local_bin_path: "/usr/local/bin"
 
 promtail_service_name: promtail
-promtail_user_name: promtail
-promtail_group_name: promtail
 promtail_version: "2.2.1"
 promtail_force_install: false
 

--- a/ansible/roles/promtail/defaults/main.yml
+++ b/ansible/roles/promtail/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+
+local_bin_path: "/usr/local/bin"
+
+promtail_service_name: promtail
+promtail_user_name: promtail
+promtail_group_name: promtail
+promtail_version: "2.2.1"
+promtail_force_install: false
+
+promtail_caddy_site: true

--- a/ansible/roles/promtail/handlers/main.yml
+++ b/ansible/roles/promtail/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: restart promtail
+  systemd:
+    name: promtail
+    daemon_reload: yes
+    state: restarted

--- a/ansible/roles/promtail/tasks/install.yml
+++ b/ansible/roles/promtail/tasks/install.yml
@@ -100,5 +100,6 @@
     t_caddy_site_default_settings: true
     t_caddy_site_secure_headers: true
     t_caddy_site_reverse_proxy: "localhost:9080"
+  when: promtail_caddy_site
   tags:
     - caddy

--- a/ansible/roles/promtail/tasks/install.yml
+++ b/ansible/roles/promtail/tasks/install.yml
@@ -7,36 +7,21 @@
     state: present
     update_cache: yes
 
-- name: Creating promtail group
-  group:
-    name: "{{ promtail_group_name }}"
-    system: yes
-
-- name: Creating promtail user
-  user:
-    name: "{{ promtail_user_name }}"
-    group: "{{ promtail_group_name }}"
-    system: yes
-    shell: "/sbin/nologin"
-    comment: "{{ promtail_user_name }} nologin User"
-    createhome: no
-    home: "/data/promtail/"
-
 - name: Creates promtail data directory
   file:
     path: "/data/promtail/"
     state: directory
-    owner: "{{ promtail_user_name }}"
-    group: "{{ promtail_group_name }}"
-    mode: 0755
+    owner: root
+    group: root
+    mode: 0750
 
 - name: Creates promtail config directory
   file:
     path: "/etc/promtail/"
     state: directory
     owner: root
-    group: "{{ promtail_group_name }}"
-    mode: 0770
+    group: root
+    mode: 0750
 
 - name: Get current promtail version
   command: "{{ local_bin_path }}/promtail -version"
@@ -66,10 +51,10 @@
       copy:
         src: "/tmp/promtail-linux-amd64"
         dest: "{{ local_bin_path }}/promtail"
-        owner: "{{ promtail_user_name }}"
-        group: "{{ promtail_group_name }}"
+        owner: root
+        group: root
         remote_src: yes
-        mode: 0755
+        mode: 0750
       notify:
         - restart promtail
 
@@ -77,6 +62,9 @@
   template:
     src: promtail.yaml.j2
     dest: /etc/promtail/promtail.yaml
+    owner: root
+    group: root
+    mode: 0640
   notify:
     - restart promtail
 

--- a/ansible/roles/promtail/tasks/install.yml
+++ b/ansible/roles/promtail/tasks/install.yml
@@ -1,0 +1,116 @@
+---
+
+- name: install required promtail packages
+  apt:
+    pkg:
+      - unzip
+    state: present
+    update_cache: yes
+
+- name: Creating promtail group
+  group:
+    name: "{{ promtail_group_name }}"
+    system: yes
+
+- name: Creating promtail user
+  user:
+    name: "{{ promtail_user_name }}"
+    group: "{{ promtail_group_name }}"
+    system: yes
+    shell: "/sbin/nologin"
+    comment: "{{ promtail_user_name }} nologin User"
+    createhome: no
+    home: "/data/promtail/"
+
+- name: Creates promtail data directory
+  file:
+    path: "/data/promtail/"
+    state: directory
+    owner: "{{ promtail_user_name }}"
+    group: "{{ promtail_group_name }}"
+    mode: 0755
+
+- name: Creates promtail config directory
+  file:
+    path: "/etc/promtail/"
+    state: directory
+    owner: root
+    group: "{{ promtail_group_name }}"
+    mode: 0770
+
+- name: Get current promtail version
+  command: "{{ local_bin_path }}/promtail -version"
+  check_mode: no
+  changed_when: false
+  failed_when: false
+  register: __promtail_version
+
+- name: Determine whether we need to install promtail
+  set_fact:
+    # if the version command failed, OR the parsed version did not match, then we install
+    _install_promtail: "{% if __promtail_version.rc != 0 or __promtail_version.stdout_lines[0].split(' ')[2] != promtail_version %}true{% else %}false{% endif %}"
+
+- name: Install promtail
+  when: _install_promtail or promtail_force_install
+  block:
+    - name: Download promtail
+      become: no
+      unarchive:
+        src: "https://github.com/grafana/loki/releases/download/v{{ promtail_version }}/promtail-linux-amd64.zip"
+        dest: /tmp/
+        remote_src: yes
+
+    - name: Copy promtail file to bin
+      # Skip this when in --check mode as the download would have been skipped
+      when: not ansible_check_mode
+      copy:
+        src: "/tmp/promtail-linux-amd64"
+        dest: "{{ local_bin_path }}/promtail"
+        owner: "{{ promtail_user_name }}"
+        group: "{{ promtail_group_name }}"
+        remote_src: yes
+        mode: 0755
+      notify:
+        - restart promtail
+
+- name: promtail config file
+  template:
+    src: promtail.yaml.j2
+    dest: /etc/promtail/promtail.yaml
+  notify:
+    - restart promtail
+
+- name: Create Unit file for promtail
+  template: src=promtail.service.j2 dest=/etc/systemd/system/promtail.service mode=644
+  notify:
+    - restart promtail
+
+# Trigger systemctl reload/restart if needed
+- name: Flush handlers
+  meta: flush_handlers
+
+- name: start promtail service
+  service: name=promtail.service state=started enabled=yes
+
+- name: Check if promtail is accessible
+  uri:
+    url: http://localhost:9080
+    method: GET
+    status_code: 200
+
+- name: configure caddy for promtail
+  include_role:
+    name: caddy
+    apply:
+      tags:
+        - caddy
+    tasks_from: add_site
+    public: no
+  vars:
+    t_caddy_site_name: promtail
+    t_caddy_site_host: "promtail.{{ inventory_hostname }}"
+    t_caddy_site_default_settings: true
+    t_caddy_site_secure_headers: true
+    t_caddy_site_reverse_proxy: "localhost:9080"
+  tags:
+    - caddy

--- a/ansible/roles/promtail/tasks/main.yml
+++ b/ansible/roles/promtail/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- include: install.yml
+  become: yes
+  tags:
+    - promtail

--- a/ansible/roles/promtail/templates/promtail.service.j2
+++ b/ansible/roles/promtail/templates/promtail.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description={{ promtail_service_name }}
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User={{ promtail_user_name }}
+Group={{ promtail_group_name }}
+Restart=on-abnormal
+Type=simple
+ExecStart=/usr/local/bin/promtail --config.file=/etc/promtail/promtail.yaml
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/promtail/templates/promtail.service.j2
+++ b/ansible/roles/promtail/templates/promtail.service.j2
@@ -4,8 +4,8 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-User={{ promtail_user_name }}
-Group={{ promtail_group_name }}
+User=root
+Group=root
 Restart=on-abnormal
 Type=simple
 ExecStart=/usr/local/bin/promtail --config.file=/etc/promtail/promtail.yaml

--- a/ansible/roles/promtail/templates/promtail.yaml.j2
+++ b/ansible/roles/promtail/templates/promtail.yaml.j2
@@ -1,0 +1,18 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://localhost:3100/loki/api/v1/push
+
+scrape_configs:
+- job_name: system
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: varlogs
+      __path__: /var/log/*log

--- a/ansible/roles/promtail/templates/promtail.yaml.j2
+++ b/ansible/roles/promtail/templates/promtail.yaml.j2
@@ -1,3 +1,8 @@
+# Rule 1 of Loki/promtail is limit the use of dynamic labels
+# Ideally, ensure there is a set limit of values for them
+# Every new label value increases the Loki streams
+
+
 server:
   http_listen_port: 9080
   grpc_listen_port: 0
@@ -9,29 +14,96 @@ clients:
   - url: http://localhost:3100/loki/api/v1/push
 
 scrape_configs:
-  - job_name: system
+  # This is far from ideal - we aren't properly considering the file timestamps for example
+  # But, it's a suitable catchall with static labels
+  - job_name: system-varlogs
     static_configs:
     - targets:
         - localhost
       labels:
         job: varlogs
-        __path__: /var/log/*log
+        # Match all the *.log + the apt/history.log (exclude syslog)
+        __path__: /var/log/{*,apt/history}.log
+        instance: {{ inventory_hostname }}
+        region: egll
+
+    pipeline_stages:
+      - match:
+          # Skip the auth (SSHd) and kernel logs which already end up in journald
+          selector: '{filename=~"/var/log/(auth.log|kern.log)"}'
+          action: drop
+          drop_counter_reason: promtail_duplicate_logs
+
 
   - job_name: journal
     journal:
+      # The journald labels are already available, but this logs them
       json: true
       max_age: 12h
-      #path: /var/log/journal
+
       labels:
         job: systemd-journal
-        host: {{ inventory_hostname }}
-        region: lon1
+        instance: {{ inventory_hostname }}
+        region: egll
+
     relabel_configs:
-      - source_labels: ['__journal__systemd_unit']
-        target_label: systemd_unit
-      - source_labels:
-        - __journal__hostname
-        target_label: nodename
-      - source_labels:
-        - __journal_syslog_identifier
-        target_label: syslog_identifier
+      # We take the systemd service name and set as the "app" label
+      # This is only okay because we remove the label for generic services, later
+      - action: replace
+        source_labels: ['__journal__systemd_unit']
+        regex: (.*)\.service
+        target_label: app
+
+    pipeline_stages:
+
+      # This stage is only going to run for caddy.service
+      - match:
+          selector: '{app="caddy"}'
+          pipeline_name: caddy
+          stages:
+            # While the journald keys are already "private" labels, we must decode the JSON to get the MESSAGE key
+            - json:
+                expressions:
+                  caddy_message: MESSAGE
+            # Second JSON decode is needed as the Caddy logs are encoded
+            - json:
+                expressions:
+                  # We grab the TLS servername - this is the cert we served and limited by the Caddy config
+                  server_name: request.tls.server_name
+                  # The Host header shouldn't be put into a label as technically user controlled
+                  http_host: request.host
+                  http_method: request.method
+                  msg:
+                  size:
+                  duration:
+                source: caddy_message
+
+            # Add the server_name as a label (as the values are constrained)
+            # Add the method for the metrics only
+            - labels:
+                server_name:
+                method: http_method
+
+            - metrics:
+                caddy_http_response_duration_seconds:
+                  type: Histogram
+                  description: "Histogram of times to first byte in response bodies"
+                  source: duration
+                  config:
+                    buckets: [0.001,0.0025,0.005,0.010,0.025,0.050,0.10,0.50,1.00,2.50,5.00]
+
+            # Remove now we no longer need it
+            - labeldrop:
+                - method
+
+
+      # This is crucial as it ensure the "app" values are defined (and avoids many Loki streams)
+      # These more generic logs journald can be examined with a search of {app=""}
+      - match:
+          # All the services we are specifically interested in, this won't match, thus will leave "app"
+          selector: '{app!~"caddy|prometheus|grafana-server|loki|promtail"}'
+          pipeline_name: generic_app
+          stages:
+            - labeldrop:
+                - app
+

--- a/ansible/roles/promtail/templates/promtail.yaml.j2
+++ b/ansible/roles/promtail/templates/promtail.yaml.j2
@@ -3,16 +3,35 @@ server:
   grpc_listen_port: 0
 
 positions:
-  filename: /tmp/positions.yaml
+  filename: /data/promtail/positions.yaml
 
 clients:
   - url: http://localhost:3100/loki/api/v1/push
 
 scrape_configs:
-- job_name: system
-  static_configs:
-  - targets:
-      - localhost
-    labels:
-      job: varlogs
-      __path__: /var/log/*log
+  - job_name: system
+    static_configs:
+    - targets:
+        - localhost
+      labels:
+        job: varlogs
+        __path__: /var/log/*log
+
+  - job_name: journal
+    journal:
+      json: true
+      max_age: 12h
+      #path: /var/log/journal
+      labels:
+        job: systemd-journal
+        host: {{ inventory_hostname }}
+        region: lon1
+    relabel_configs:
+      - source_labels: ['__journal__systemd_unit']
+        target_label: systemd_unit
+      - source_labels:
+        - __journal__hostname
+        target_label: nodename
+      - source_labels:
+        - __journal_syslog_identifier
+        target_label: syslog_identifier

--- a/ansible/roles/promtail/templates/promtail.yaml.j2
+++ b/ansible/roles/promtail/templates/promtail.yaml.j2
@@ -4,7 +4,10 @@
 
 
 server:
+  # Random port is chosen when 0
+  http_listen_address: localhost
   http_listen_port: 9080
+  grpc_listen_address: localhost
   grpc_listen_port: 0
 
 positions:


### PR DESCRIPTION
* Monitor server _only_ (not yet ready/possible for others to log into here yet)
* Loki will eventually need to be accessible by the other servers, but auth will need resolving between servers (either basic auth or certs)
* Lots of Loki config is possible... we'll start with the training wheels. Should likely end up shipping the logs into DO Spaces (?)
* Will need to keep an eye on things here with Loki..!
* Promtail will ship all of journald logs and whatever other files we want (currently a few from `/var/log/` not already in journald)
* Loki is auto configured as a datasource in Grafana
* We are create prometheus metrics off the caddy stats currently, could do this with other logs as well if we wanted
* Prometheus now monitors Grafana, Loki, Promtail, Caddy as well