### PR TITLE
Quick fixes: typos / Caddy retry / Prom version check

### DIFF
--- a/ansible/roles/caddy/tasks/install.yml
+++ b/ansible/roles/caddy/tasks/install.yml
@@ -80,6 +80,7 @@
   uri:
     url: https://{{ inventory_hostname }}/
     method: GET
+    status_code: 204
   register: _result
   until: _result.status == 204
   retries: 36 # 36 * 5 seconds = 3 minutes

--- a/ansible/roles/loki/tasks/install.yml
+++ b/ansible/roles/loki/tasks/install.yml
@@ -128,9 +128,9 @@
     tasks_from: grafana_add_datasource
     public: no
   vars:
-    t_grafana_dashboard_name: Loki
-    t_grafana_dashboard_type: loki
-    t_grafana_dashboard_url: "http://localhost:3100"
-    t_grafana_dashboard_uid: "glim-loki"
+    t_grafana_datasource_name: Loki
+    t_grafana_datasource_type: loki
+    t_grafana_datasource_url: "http://localhost:3100"
+    t_grafana_datasource_uid: "glim-loki"
   tags:
     - grafana

--- a/ansible/roles/monitor/tasks/grafana_add_datasource.yml
+++ b/ansible/roles/monitor/tasks/grafana_add_datasource.yml
@@ -10,20 +10,20 @@
 #    tasks_from: grafana_add_datasource
 #    public: no
 #  vars:
-#    t_grafana_dashboard_version: 1
-#    t_grafana_dashboard_name: Prometheus
-#    t_grafana_dashboard_type: prometheus
-#    t_grafana_dashboard_url: "http://localhost:9090"
-#    t_grafana_dashboard_http_method: "POST"
-#    t_grafana_dashboard_uid: false
-#    t_grafana_dashboard_is_default: false
+#    t_grafana_datasource_version: 1
+#    t_grafana_datasource_name: Prometheus
+#    t_grafana_datasource_type: prometheus
+#    t_grafana_datasource_url: "http://localhost:9090"
+#    t_grafana_datasource_http_method: "POST"
+#    t_grafana_datasource_uid: "datasource-identifier"
+#    t_grafana_datasource_is_default: false
 #  tags:
 #    - grafana
 
-- name: configure grafana datasource for {{ t_grafana_dashboard_name }}
+- name: configure grafana datasource for {{ t_grafana_datasource_name }}
   template:
     src: grafana-datasource.yaml.j2
-    dest: "{{ grafana_conf_dir }}/provisioning/datasources/{{ t_grafana_dashboard_name | replace(' ', '_') | lower }}.yaml"
+    dest: "{{ grafana_conf_dir }}/provisioning/datasources/{{ t_grafana_datasource_name | replace(' ', '_') | lower }}.yaml"
     owner: root
     group: grafana
     mode: 0640

--- a/ansible/roles/monitor/tasks/prometheus.yml
+++ b/ansible/roles/monitor/tasks/prometheus.yml
@@ -102,12 +102,12 @@
 - name: configure prometheus for grafana
   include: grafana_add_datasource.yml
   vars:
-    t_grafana_dashboard_name: Prometheus
-    t_grafana_dashboard_type: prometheus
-    t_grafana_dashboard_url: "http://localhost:9090"
-    t_grafana_dashboard_http_method: "POST"
-    t_grafana_dashboard_uid: "glim-prometheus"
-    t_grafana_dashboard_is_default: true
+    t_grafana_datasource_name: Prometheus
+    t_grafana_datasource_type: prometheus
+    t_grafana_datasource_url: "http://localhost:9090"
+    t_grafana_datasource_http_method: "POST"
+    t_grafana_datasource_uid: "glim-prometheus"
+    t_grafana_datasource_is_default: true
   tags:
     - grafana
 

--- a/ansible/roles/monitor/tasks/prometheus.yml
+++ b/ansible/roles/monitor/tasks/prometheus.yml
@@ -42,14 +42,6 @@
   set_fact:
     # if the version command failed, OR the parsed version did not match, then we install
     _install_prometheus: "{% if __prometheus_version.rc != 0 or __prometheus_version.stdout_lines[0].split(' ')[2] != prometheus_version %}true{% else %}false{% endif %}"
-  when: __prometheus_version.stdout_lines
-
-# Pre 2.26.0, the version info was to stderr... This block can be removed after infra upgrades
-- name: Determine whether we need to install prometheus
-  set_fact:
-    # if the version command failed, OR the parsed version did not match, then we install
-    _install_prometheus: "{% if __prometheus_version.rc != 0 or __prometheus_version.stderr_lines[0].split(' ')[2] != prometheus_version %}true{% else %}false{% endif %}"
-  when: __prometheus_version.stderr_lines
 
 - name: Install prometheus
   when: _install_prometheus or prometheus_force_install

--- a/ansible/roles/monitor/templates/grafana-datasource.yaml.j2
+++ b/ansible/roles/monitor/templates/grafana-datasource.yaml.j2
@@ -1,27 +1,27 @@
 # config file version
-apiVersion: {{ t_grafana_dashboard_version | default("1") }}
+apiVersion: {{ t_grafana_datasource_version | default("1") }}
 
 # list of datasources to insert/update depending
 # what's available in the database
 datasources:
   # <string, required> name of the datasource. Required
-  - name: {{ t_grafana_dashboard_name }}
+  - name: {{ t_grafana_datasource_name }}
     # <string, required> datasource type. Required
-    type: {{ t_grafana_dashboard_type }}
+    type: {{ t_grafana_datasource_type }}
     # <string, required> access mode. proxy or direct (Server or Browser in the UI). Required
     access: proxy
 
     # <string> custom UID which can be used to reference this datasource in other parts of the configuration, if not specified will be generated automatically
-    uid: {{ t_grafana_dashboard_uid }}
+    uid: {{ t_grafana_datasource_uid }}
     # <string> url
-    url: {{ t_grafana_dashboard_url }}
+    url: {{ t_grafana_datasource_url }}
 
     # <bool> mark as default datasource. Max one per org
-    isDefault: {{ t_grafana_dashboard_is_default | default(false) | string | lower }}
+    isDefault: {{ t_grafana_datasource_is_default | default(false) | string | lower }}
     # <map> fields that will be converted to json and stored in jsonData
     jsonData:
-{% if t_grafana_dashboard_http_method is defined %}
-      httpMethod: "{{ t_grafana_dashboard_http_method }}"
+{% if t_grafana_datasource_http_method is defined %}
+      httpMethod: "{{ t_grafana_datasource_http_method }}"
 {% endif %}
 
     version: 1


### PR DESCRIPTION
Super minor changes

* I confused myself and labelled the datasources "dashboards" - this is wrong!
* Caddy URI fix per discussions
* Prometheus no longer needs to check the stderr output - that was for compatibility when upgrading to the new version