### PR TITLE
Quick fix for Loki

### DIFF
--- a/ansible/roles/loki/templates/loki.yaml.j2
+++ b/ansible/roles/loki/templates/loki.yaml.j2
@@ -1,12 +1,12 @@
 auth_enabled: false
 
 server:
-  # Random port is chosen when 0
+  # Random port should not be used for Loki
   http_listen_address: localhost
   http_listen_port: 3100
   grpc_listen_address: localhost
-  #grpc_listen_port: 9096
-  grpc_listen_port: 0
+  grpc_listen_port: 9095
+
 
 ingester:
   wal:


### PR DESCRIPTION
We need to use a defined GRPC port for Loki.

Even though it's okay with it, for the clients that connect, it uses the wrong port...