### PR TITLE
Ansible: All nodes log shipping

### DIFF
--- a/ansible/hosts.example
+++ b/ansible/hosts.example
@@ -29,6 +29,10 @@ some-orchestrator-server
 [monitor]
 monitoring-server
 
+[monitor:vars]
+# The monitoring server generates its own logs which causes more logs
+promtail_log_batchwait_seconds=15
+
 [node_exporter:children]
 monitor
 ftl

--- a/ansible/hosts.example
+++ b/ansible/hosts.example
@@ -35,3 +35,6 @@ ftl
 
 [all:vars]
 ansible_user=root
+
+loki_host=loki.monitoring-server
+loki_caddy_basicauth_promtail=very_secret_password_which_is_greater_than_63_characters_is_best

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -5,6 +5,10 @@
     - caddy
     - monitor
     - loki
+
+- name: monitoring clients
+  hosts: all
+  roles:
     - promtail
     - prometheus-node-exporter
 
@@ -12,30 +16,22 @@
   hosts: web
   serial: 1
   roles:
-    - promtail
     - glimesh-web
-    - prometheus-node-exporter
 
 - name: ftl orchestrator
   hosts: ftl_orchestrator
   roles:
-    - promtail
     - janus-ftl-orchestrator
-    - prometheus-node-exporter
 
 - name: ftl ingest
   hosts: ftl_ingest
   roles:
-    - promtail
     - janus-ftl-plugin
-    - prometheus-node-exporter
 
 - name: ftl edge
   hosts: ftl_edge
   vars:
     ftl_node_kind: edge
   roles:
-    - promtail
     - janus-ftl-plugin
     - janus-ftl-nginx-ssl
-    - prometheus-node-exporter

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,20 +1,32 @@
 
+- name: monitoring server
+  hosts: monitor
+  roles:
+    - caddy
+    - monitor
+    - loki
+    - promtail
+    - prometheus-node-exporter
+
 - name: web
   hosts: web
   serial: 1
   roles:
+    - promtail
     - glimesh-web
     - prometheus-node-exporter
 
 - name: ftl orchestrator
   hosts: ftl_orchestrator
   roles:
+    - promtail
     - janus-ftl-orchestrator
     - prometheus-node-exporter
 
 - name: ftl ingest
   hosts: ftl_ingest
   roles:
+    - promtail
     - janus-ftl-plugin
     - prometheus-node-exporter
 
@@ -23,15 +35,7 @@
   vars:
     ftl_node_kind: edge
   roles:
+    - promtail
     - janus-ftl-plugin
     - janus-ftl-nginx-ssl
-    - prometheus-node-exporter
-
-- name: monitoring server
-  hosts: monitor
-  roles:
-    - caddy
-    - monitor
-    - loki
-    - promtail
     - prometheus-node-exporter

--- a/ansible/roles/caddy/tasks/gen_basic_pass.yml
+++ b/ansible/roles/caddy/tasks/gen_basic_pass.yml
@@ -1,0 +1,62 @@
+---
+
+# Given a var name in t_caddy_basic_pass_var_name, we check if the _hash var of
+# it exists. If it exists, all good, otherwise, we generate a new hash and alert
+# the user they should set this new var
+#
+# It's not a true failure as it shouldn't break anything when not set - but it
+# will generate and change the file _every_ run which is bad.
+#
+# Note: This is a result of the bcrypt hashing that caddy uses for basicauth.
+#
+# Vars to set when calling this task (eg. via include_role):
+#
+#  include_role:
+#    name: caddy
+#    apply:
+#      tags:
+#        - caddy
+#        - caddy_pass
+#    tasks_from: gen_basic_pass
+#    public: no
+#  vars:
+#    t_caddy_basic_pass_var_name: "service_caddy_basicauth"
+#  tags:
+#    - caddy
+#    - caddy_pass
+
+- name: Determine if hashed password is already set
+  set_fact:
+    # If the _hash var has been set, then this is True, else is False
+    __hashed_password_has_been_set: "{{ true if lookup('vars', t_caddy_basic_pass_var_name + '_hash', default=False) else false}}"
+
+- debug:
+    msg: "A hashed password was supplied for {{ t_caddy_basic_pass_var_name }}: {{ __hashed_password_has_been_set }}"
+  tags:
+    - caddy
+    - caddy_pass
+
+- name: Generate Caddy basicauth password hash for {{ t_caddy_basic_pass_var_name }}
+  # The lookup grabs the plaintext password that has been set
+  command: "caddy hash-password --plaintext {{ lookup('vars', t_caddy_basic_pass_var_name) }}"
+  check_mode: no
+  changed_when: false
+  register: __hash_password
+  when: not __hashed_password_has_been_set
+  tags:
+    - caddy
+    - caddy_pass
+
+- name: Set value of {{ t_caddy_basic_pass_var_name }}_hash var to the new password hash
+  set_fact:
+    "{{ t_caddy_basic_pass_var_name }}_hash": "{{ __hash_password.stdout_lines[0] }}"
+  when: not __hashed_password_has_been_set
+
+- debug:
+    msg:
+      - "!! NOTE !! : We've generated a *unique* password hash for the value of {{ t_caddy_basic_pass_var_name }}"
+      - "Please now set the following var in the playbook so we can skip this in the future."
+      - "{{ t_caddy_basic_pass_var_name }}_hash: {{ lookup('vars', t_caddy_basic_pass_var_name + '_hash') }}"
+  failed_when: true
+  ignore_errors: true
+  when: not __hashed_password_has_been_set

--- a/ansible/roles/caddy/tasks/install.yml
+++ b/ansible/roles/caddy/tasks/install.yml
@@ -77,6 +77,7 @@
   service: name=caddy.service state=started enabled=yes
 
 - name: Check if caddy is accessible
+  check_mode: no
   uri:
     url: https://{{ inventory_hostname }}/
     method: GET

--- a/ansible/roles/loki/defaults/main.yml
+++ b/ansible/roles/loki/defaults/main.yml
@@ -8,4 +8,8 @@ loki_group_name: loki
 loki_version: "2.2.1"
 loki_force_install: false
 
-loki_caddy_site: false
+loki_caddy_site: true
+loki_caddy_basicauth_promtail: some_value
+# This hash does not need to be generated manually, instead the playbook
+# will throw an (ignored) error highlighting what to set it to.
+loki_caddy_basicauth_promtail_hash: ""

--- a/ansible/roles/loki/tasks/install.yml
+++ b/ansible/roles/loki/tasks/install.yml
@@ -141,6 +141,20 @@
   tags:
     - caddy
 
+- name: Check if Loki is protected
+  check_mode: no
+  uri:
+    url: "https://loki.{{ inventory_hostname }}/"
+    method: GET
+    status_code: 401
+  register: _result
+  until: _result.status == 401
+  retries: 36 # 36 * 5 seconds = 3 minutes
+  delay: 5 # Every 5 seconds
+  when: loki_caddy_site and not acme_staging
+  tags:
+    - caddy
+
 - name: configure grafana for loki
   include_role:
     name: monitor

--- a/ansible/roles/loki/tasks/install.yml
+++ b/ansible/roles/loki/tasks/install.yml
@@ -101,6 +101,24 @@
     method: GET
     status_code: 200
 
+# This will check if loki_caddy_basicauth_promtail_hash is set and generate if needed
+- name: prepare loki basicauth password hash for promtail
+  include_role:
+    name: caddy
+    apply:
+      tags:
+        - caddy
+        - caddy_pass
+    tasks_from: gen_basic_pass
+    public: no
+  vars:
+    # Var where
+    t_caddy_basic_pass_var_name: "loki_caddy_basicauth_promtail"
+  when: loki_caddy_site
+  tags:
+    - caddy
+    - caddy_pass
+
 - name: configure caddy for loki
   include_role:
     name: caddy
@@ -115,6 +133,10 @@
     t_caddy_site_default_settings: true
     t_caddy_site_secure_headers: true
     t_caddy_site_reverse_proxy: "localhost:3100"
+    t_caddy_site_extra_conf: |
+      basicauth  {
+          promtail {{ loki_caddy_basicauth_promtail_hash }}
+      }
   when: loki_caddy_site
   tags:
     - caddy

--- a/ansible/roles/monitor/templates/prometheus.conf.j2
+++ b/ansible/roles/monitor/templates/prometheus.conf.j2
@@ -1,3 +1,10 @@
+#
+# Label standards:
+#   instance - hostname of the node (no port/scheme/URL path)
+#   app - matches the loki label configs (job labels there are different)
+#   job - corresponds to the scrape config (often, but not always the same as app)
+#
+
 global:
   scrape_interval: 15s
 
@@ -8,6 +15,11 @@ rule_files:
 scrape_configs:
   - job_name: 'prometheus'
     #scrape_interval: 5s
+    metric_relabel_configs:
+      # Drop metrics for irrelevant k8 series' which is currently unused by prometheus (always 0)
+      - source_labels: [__name__]
+        regex: '^(prometheus_sd_kubernetes).*'
+        action: drop
     static_configs:
       - targets: ['localhost:9090']
         labels:
@@ -24,6 +36,11 @@ scrape_configs:
 
   - job_name: 'loki'
     #scrape_interval: 5s
+    metric_relabel_configs:
+      # Drop metrics for irrelevant etcd series' which is currently unused by loki (always 0)
+      - source_labels: [__name__]
+        regex: '^(etcd).*'
+        action: drop
     static_configs:
       - targets: ['localhost:3100']
         labels:
@@ -49,9 +66,10 @@ scrape_configs:
   - job_name: 'node_exporter'
     scrape_interval: 5s
     static_configs:
-{% for host in groups['node_exporter'] %}
+{% for host in groups["all"] %}
       - targets: ['{{ host }}:9100']
         labels:
+          instance: {{ host }}
           region: {{ hostvars[host].region }}
 {% if hostvars[host].ftl_node_kind is defined %}
           ftl_node_kind: {{ hostvars[host].ftl_node_kind }}
@@ -64,10 +82,10 @@ scrape_configs:
     params:
       module: [http_json_200]  # Look for a HTTP 200 with JSON data
     relabel_configs:
+      # Use the given address ("target") and turn it into a __param used to query the blackbox_exporter
       - source_labels: [__address__]
         target_label: __param_target
-      - source_labels: [__param_target]
-        target_label: instance
+      # Prometheus needs the address of the blackbox_exporter
       - target_label: __address__
         replacement: localhost:9115  # The blackbox exporter's real hostname:port.
     static_configs:
@@ -75,6 +93,8 @@ scrape_configs:
 {% if inventory_hostname != host %}
       - targets: ['https://{{ host }}/janus/info']
         labels:
+          app: janus
+          instance: {{ host }}
           region: {{ hostvars[host].region }}
           ftl_node_kind: {{ hostvars[host].ftl_node_kind }}
 {% endif %}
@@ -87,10 +107,10 @@ scrape_configs:
     params:
       module: [ftl_ping]  # Look for a 201 response to a PING
     relabel_configs:
+      # Use the given address ("target") and turn it into a __param used to query the blackbox_exporter
       - source_labels: [__address__]
         target_label: __param_target
-      - source_labels: [__param_target]
-        target_label: instance
+      # Prometheus needs the address of the blackbox_exporter
       - target_label: __address__
         replacement: localhost:9115  # The blackbox exporter's real hostname:port.
     static_configs:
@@ -98,6 +118,8 @@ scrape_configs:
 {% if inventory_hostname != host %}
       - targets: ['{{ host }}:8084']
         labels:
+          app: janus
+          instance: {{ host }}
           region: {{ hostvars[host].region }}
           ftl_node_kind: {{ hostvars[host].ftl_node_kind }}
 {% endif %}

--- a/ansible/roles/monitor/templates/prometheus.conf.j2
+++ b/ansible/roles/monitor/templates/prometheus.conf.j2
@@ -47,14 +47,6 @@ scrape_configs:
           app: loki
           instance: {{ inventory_hostname }}
 
-  - job_name: 'promtail'
-    #scrape_interval: 5s
-    static_configs:
-      - targets: ['localhost:9080']
-        labels:
-          app: promtail
-          instance: {{ inventory_hostname }}
-
   - job_name: 'caddy'
     #scrape_interval: 5s
     static_configs:
@@ -62,6 +54,31 @@ scrape_configs:
         labels:
           app: caddy
           instance: {{ inventory_hostname }}
+
+  - job_name: 'promtail'
+    #scrape_interval: 5s
+    metric_relabel_configs:
+      # promtail_custom metrics will have their own app/job, let's relabel the app only
+      - source_labels: [exported_app]
+        target_label: app
+      # Remove the "exported" labels now we don't need them
+      - regex: 'exported_(app|job)'
+        action: labeldrop
+      # Drop metrics for irrelevant etcd/cortex/prometheus series' which are unused by promtail (always 0)
+      - source_labels: [__name__]
+        regex: '^(etcd|cortex|prometheus).*'
+        action: drop
+    static_configs:
+{% for host in groups["all"] %}
+      - targets: ['{{ host }}:9080']
+        labels:
+          app: promtail
+          instance: {{ host }}
+          region: {{ hostvars[host].region }}
+{% if hostvars[host].ftl_node_kind is defined %}
+          ftl_node_kind: {{ hostvars[host].ftl_node_kind }}
+{% endif %}
+{% endfor %}
 
   - job_name: 'node_exporter'
     scrape_interval: 5s

--- a/ansible/roles/promtail/defaults/main.yml
+++ b/ansible/roles/promtail/defaults/main.yml
@@ -7,3 +7,12 @@ promtail_version: "2.2.1"
 promtail_force_install: false
 
 promtail_caddy_site: false
+
+# Which systemd services do we want to specifically label
+promtail_journald_app_whitelist: "caddy|prometheus|grafana-server|loki|promtail|glimesh|janus|orchestrator"
+promtail_log_batchwait_seconds: 1
+
+# Set to the configured Loki site name (likely "loki." + monitoring server hostname)
+loki_host: loki.monitoring.example.com
+loki_caddy_basicauth_promtail: some_value
+loki_skip_verify: false

--- a/ansible/roles/promtail/templates/promtail.yaml.j2
+++ b/ansible/roles/promtail/templates/promtail.yaml.j2
@@ -27,6 +27,9 @@ clients:
     external_labels:
       instance: {{ inventory_hostname }}
       region: {{ region }}
+{% if ftl_node_kind is defined %}
+      ftl_node_kind: {{ ftl_node_kind }}
+{% endif %}
 
 scrape_configs:
   # This is far from ideal - we aren't properly considering the file timestamps for example

--- a/ansible/roles/promtail/templates/promtail.yaml.j2
+++ b/ansible/roles/promtail/templates/promtail.yaml.j2
@@ -14,7 +14,16 @@ positions:
   filename: /data/promtail/positions.yaml
 
 clients:
-  - url: http://localhost:3100/loki/api/v1/push
+  - url: https://{{ loki_host }}/loki/api/v1/push
+    batchwait: {{ promtail_log_batchwait_seconds }}s
+    basic_auth:
+      username: promtail
+      password: {{ loki_caddy_basicauth_promtail }}
+    tls_config:
+      insecure_skip_verify: {{ loki_skip_verify }}
+    external_labels:
+      instance: {{ inventory_hostname }}
+      region: {{ region }}
 
 scrape_configs:
   # This is far from ideal - we aren't properly considering the file timestamps for example
@@ -27,8 +36,6 @@ scrape_configs:
         job: varlogs
         # Match all the *.log + the apt/history.log (exclude syslog)
         __path__: /var/log/{*,apt/history}.log
-        instance: {{ inventory_hostname }}
-        region: egll
 
     pipeline_stages:
       - match:
@@ -46,8 +53,6 @@ scrape_configs:
 
       labels:
         job: systemd-journal
-        instance: {{ inventory_hostname }}
-        region: egll
 
     relabel_configs:
       # We take the systemd service name and set as the "app" label

--- a/ansible/roles/promtail/templates/promtail.yaml.j2
+++ b/ansible/roles/promtail/templates/promtail.yaml.j2
@@ -1,11 +1,14 @@
 # Rule 1 of Loki/promtail is limit the use of dynamic labels
 # Ideally, ensure there is a set limit of values for them
 # Every new label value increases the Loki streams
-
+#
+# Timestamp parsing is probably a bad route for journald logs as it already
+# will have reliably/accuaretly recorded at the ms level.
+# Might be worth doing for conventional file based logs when they are relevant.
 
 server:
   # Random port is chosen when 0
-  http_listen_address: localhost
+  http_listen_address: 0.0.0.0
   http_listen_port: 9080
   grpc_listen_address: localhost
   grpc_listen_port: 0

--- a/ansible/roles/promtail/templates/promtail.yaml.j2
+++ b/ansible/roles/promtail/templates/promtail.yaml.j2
@@ -97,6 +97,8 @@ scrape_configs:
                   type: Histogram
                   description: "Histogram of times to first byte in response bodies"
                   source: duration
+                  # The labels are defined so the /metrics won't grow uncontrollably, set long idle timer
+                  max_idle_duration: 12h
                   config:
                     buckets: [0.001,0.0025,0.005,0.010,0.025,0.050,0.10,0.50,1.00,2.50,5.00]
 
@@ -105,13 +107,18 @@ scrape_configs:
                 - method
 
 
-      # This is crucial as it ensure the "app" values are defined (and avoids many Loki streams)
-      # These more generic logs journald can be examined with a search of {app=""}
+      # This is crucial as it ensure the "app" values are defined/constrained (and avoids many Loki streams)
+      # These more generic logs journald can be examined with a search of {app="generic"}
       - match:
-          # All the services we are specifically interested in, this won't match, thus will leave "app"
-          selector: '{app!~"caddy|prometheus|grafana-server|loki|promtail"}'
+          # All the services we are specifically interested in won't have their label changed
+          selector: '{app!~"{{ promtail_journald_app_whitelist }}"}'
           pipeline_name: generic_app
           stages:
-            - labeldrop:
-                - app
+            # Create a new var
+            - template:
+                source: _generic_app_name
+                template: "generic"
+            # Use new var to set "app" label
+            - labels:
+                app: _generic_app_name
 

--- a/terraform/monitor.tf
+++ b/terraform/monitor.tf
@@ -24,6 +24,7 @@ resource "cloudflare_record" "monitor_record" {
     "",
     "prometheus.",
     "grafana.",
+    "loki.",
   ])
 
   zone_id = lookup(data.cloudflare_zones.glimesh_domain_zones.zones[0], "id")


### PR DESCRIPTION
Resolves #19 

* Adjusted playbook:
  * Monitoring services is first
  * Monitoring clients (all hosts) are second - these are safe (not service impacting) to execute against larger batches

* Examples hosts file has 2 new **important** vars:
  * `loki_host` : set to the loki hostname (`loki.monitor.glimesh.tv`)
  * `loki_caddy_basicauth_promtail` : please generate a long string here - this guards against people posting random logs to us or messing with our logging server
  * Once you've ran the playbook, you should add another var here `loki_caddy_basicauth_promtail_hash` - this is given to you when the Caddy site is configured for Loki

`promtail_log_batchwait_seconds` controls how long the node will wait to send logs. It's only worth changing this on the monitoring node IMO. Probably up to 15 seconds. This is because each time we receive logs, we log that, we triggers more logs. Limiting to once every 15 seconds is fine for the monitoring node.

* Caddy include for generating a bcrypt basicauth password hash
  * It's designed so that you can supply just the password and that's fine
  * It will generate the hash if needed
  * If it generates the hash, it will fake error (which Ansible will "ignore") with a messaging telling you to set the var for next time
  * The reason is that the bcrypt hash is different each time, and setting the hash means we don't needlessly change the file each time

* Loki has a Caddy site configured for it. This is protected by HTTPS and a shared basicauth password

* Promtail pushes its logs to the HTTPS/basic auth protected endpoint. Cert is verified
* Promtail will individually label the systemd apps:
  * caddy
  * prometheus
  * grafana-server
  * loki
  * promtail
  * glimesh
  * janus
  * orchestrator
* Apps not specifically identified ^^ are labelled "generic" - though the underlying app is still recorded in the JSON
* `region` is fixed from hardcoded test value
* `ftl_node_kind` is also set appropriately

* We've cleaned up some Prometheus metrics and standardized our label names a bit
  * `instance` is now just the hostname - no extra port / URL path etc.
  * `app` corresponds to the promtail app name / systemd service.
  * `job` reflects the name of the scrape config (default) - this is mostly the same as `app` - but not always
  * Some of the default etcd/cortext/k8 metrics are dropped. These don't really use up space AFAIK (as the value is always the same), but they are pointless

