### PR TITLE
Terraform: add monitor node to web FW

### DIFF
--- a/terraform/monitor.tf
+++ b/terraform/monitor.tf
@@ -1,9 +1,15 @@
+
+resource "digitalocean_tag" "monitor" {
+  name = "monitor"
+}
+
 resource "digitalocean_droplet" "monitor" {
   image              = "ubuntu-20-04-x64"
   name               = var.monitor_hostname
   region             = "nyc3"
   size               = "s-2vcpu-2gb"
   private_networking = true
+  tags                 = [digitalocean_tag.monitor.id]
   backups            = true
 
   ssh_keys = [

--- a/terraform/web.tf
+++ b/terraform/web.tf
@@ -136,6 +136,27 @@ resource "digitalocean_firewall" "web_lb_only_traffic" {
     source_tags = [digitalocean_tag.web.id]
   }
 
+  # From Monitoring
+  inbound_rule {
+    protocol    = "icmp"
+    source_tags = [digitalocean_tag.monitor.id]
+  }
+  inbound_rule {
+    protocol    = "tcp"
+    port_range  = "8080"
+    source_tags = [digitalocean_tag.monitor.id]
+  }
+  inbound_rule {
+    protocol    = "tcp"
+    port_range  = "9080"
+    source_tags = [digitalocean_tag.monitor.id]
+  }
+  inbound_rule {
+    protocol    = "tcp"
+    port_range  = "9100"
+    source_tags = [digitalocean_tag.monitor.id]
+  }
+
   # From Load Balancer
   inbound_rule {
     protocol                  = "tcp"


### PR DESCRIPTION
* Creates a new tag for "monitor"
* Adds inbound rules to web FW for ICMP, 8080, 9080, 9100

_untested_