### PR TITLE
Ansible: blackbox_exporter memory limits

### DIFF
--- a/ansible/roles/monitor/templates/blackbox_exporter.service.j2
+++ b/ansible/roles/monitor/templates/blackbox_exporter.service.j2
@@ -8,7 +8,14 @@ User={{ blackbox_exporter_user_name }}
 Group={{ blackbox_exporter_group_name }}
 Restart=on-abnormal
 Type=simple
-ExecStart={{ local_bin_path }}/blackbox_exporter --config.file=/etc/blackbox_exporter/blackbox_exporter.conf --web.listen-address="localhost:9115"
+# History Limit is the count of test results and the count of test failures kept in memory
+ExecStart={{ local_bin_path }}/blackbox_exporter \
+                                    --config.file=/etc/blackbox_exporter/blackbox_exporter.conf \
+                                    --web.listen-address="localhost:9115" \
+                                    --history.limit 25
+
+MemoryHigh=150M
+MemoryMax=200M
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/monitor/templates/prometheus.conf.j2
+++ b/ansible/roles/monitor/templates/prometheus.conf.j2
@@ -47,6 +47,13 @@ scrape_configs:
           app: loki
           instance: {{ inventory_hostname }}
 
+  - job_name: 'blackbox_exporter'
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['localhost:9115']
+        labels:
+          instance: {{ inventory_hostname }}
+
   - job_name: 'caddy'
     scrape_interval: 30s
     metric_relabel_configs:

--- a/ansible/roles/monitor/templates/prometheus.service.j2
+++ b/ansible/roles/monitor/templates/prometheus.service.j2
@@ -8,7 +8,10 @@ User={{ prometheus_user_name }}
 Group={{ prometheus_group_name }}
 Restart=on-abnormal
 Type=simple
-ExecStart=/usr/local/bin/prometheus --config.file=/etc/prometheus/prometheus.conf --storage.tsdb.path=/data/prometheus --storage.tsdb.retention=31d
+ExecStart={{ local_bin_path }}/prometheus \
+                                    --config.file=/etc/prometheus/prometheus.conf \
+                                    --storage.tsdb.path=/data/prometheus \
+                                    --storage.tsdb.retention=31d
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Resolves #34

* I reduced the history.limit from 100 down to 25 - keeping less failures in-memory means less memory used
* Memory limits of 200M is generous...
* Swap might be worth adding. Most of the blackbox_exporter mem could be swapped as it's likely such a low hit rate
* Start monitoring the blackbox process