### PR TITLE
Ansible: bump Caddy 2.4.2

### DIFF
--- a/ansible/roles/caddy/defaults/main.yml
+++ b/ansible/roles/caddy/defaults/main.yml
@@ -4,7 +4,7 @@ letsencrypt_email: certs@example.com
 # Staging env can be used to avoid the LE ratelimits (5 identical certs per week)
 acme_staging: false
 
-caddy_version: "2.3.0"
+caddy_version: "2.4.2"
 caddy_conf_dir: "/etc/caddy"
 caddy_sites_dir: "{{ caddy_conf_dir }}/sites.d"
 caddy_snippets_dir: "{{ caddy_conf_dir }}/snippets.d"


### PR DESCRIPTION
* Should fix the ZeroSSL reissue
* Also see https://github.com/caddyserver/caddy/issues/4191