### PR TITLE
Enable playout-delay extension + NACKs + janus version bumps

### DIFF
--- a/ansible/roles/janus-ftl-plugin/defaults/main.yml
+++ b/ansible/roles/janus-ftl-plugin/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 
 libnice_version: "0.1.18"
-libsrtp_version: "v2.3.0"
-janusgateway_version: "v0.10.9"
+libsrtp_version: "v2.4.2"
+janusgateway_version: "rtp-playout-delay-extension"
 janus_ftl_plugin_version: "master"
 
 # Using an admin Glimesh account, create an "Application"

--- a/ansible/roles/janus-ftl-plugin/tasks/main.yml
+++ b/ansible/roles/janus-ftl-plugin/tasks/main.yml
@@ -144,7 +144,7 @@
 
 - name: download janus-gateway
   git:
-    repo: https://github.com/meetecho/janus-gateway.git
+    repo: https://github.com/Glimesh/janus-gateway.git
     dest: /tmp/janus-gateway
     recursive: true
     update: true
@@ -207,7 +207,7 @@
 
   # --buildtype=release
 - name: meson janus-ftl-plugin
-  shell: CC=gcc-10 CXX=g++-10 meson build/ --buildtype=debugoptimized
+  shell: CC=gcc-10 CXX=g++-10 meson build/ --buildtype=debugoptimized -D janus_playout_delay_support=true
   args:
     chdir: /tmp/janus-ftl-plugin
   # when: janus_ftl_plugin.changed

--- a/ansible/roles/janus-ftl-plugin/templates/janus.service.j2
+++ b/ansible/roles/janus-ftl-plugin/templates/janus.service.j2
@@ -36,6 +36,9 @@ Environment="FTL_SERVICE_GLIMESH_CLIENTID={{ glimesh_client_id }}"
 Environment="FTL_SERVICE_GLIMESH_CLIENTSECRET={{ glimesh_client_secret }}"
 Environment="FTL_MAX_ALLOWED_BITS_PER_SECOND=8000000"
 Environment="FTL_ROLLING_SIZE_AVG_MS=30000"
+Environment="FTL_NACK_LOST_PACKETS=1"
+Environment="FTL_PLAYOUT_DELAY_MIN_MS=400"
+Environment="FTL_PLAYOUT_DELAY_MAX_MS=4000"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
~~This is not meant to merge as-is, but I wanted a place to coordinate rolling out the janus-ftl-plugin changes I've been making and we've been discussing over on https://github.com/Glimesh/janus-ftl-plugin/pull/135.~~ (edit: those changes have merged) This follows my original plan in https://github.com/Glimesh/janus-ftl-plugin/issues/126#issuecomment-824625197

This specifically targets what changes need to happen to turn on the playout-delay extension from https://github.com/Glimesh/janus-ftl-plugin/pull/134, because it involves a few things:
- Janus must be built with a patch applied to support the playout-delay extension. For convenience I have a branch ready based on Janus v0.11.6 in my fork of janus-gateway
- Then the ftl plugin must be built with `janus_playout_delay_support=true`
- This enables support, but the ftl plugin will not actually send playout-delay values by default. You still have to set env variables FTL_PLAYOUT_DELAY_MIN_MS and FTL_PLAYOUT_DELAY_MAX_MS to reasonable values.

I totally support your idea to deploy this to just one server to start with (note playout-delay is only meaningful on edge servers though). After deploying I'd want to verify:
- [ ] In `chrome://webrtc-internals/`, the value of `jitterBufferDelay/jitterBufferEmittedCount_in_ms` should never really dip below the configured min playout delay
- [ ] Check if https://github.com/Glimesh/janus-ftl-plugin/issues/101 is mitigated. Ideally verify for the same stream that an unpatched edge node repros the issue and a patched edge node does not repro. My usual test stream is a white noise background with a small moving clock etc
- [ ] Run a stream over a lossy network to an ingest with NACKs enabled and an edge with playout-delay enabled. Compare the packet NACK and loss rates to the same content streamed to an ingest with NACKs enabled and a "legacy" edge node without playout delay enabled. Hopefully packet loss rate goes down while the NACK rate remains about the same. If the loss rate gets worse I'd be concerned.
- [ ] Let the change sit for awhile and see if anyone reports issues.

While this does implicitly bump the janus version and libsrtp version, there was not impact I saw or expected from that, just keeping up with dependencies.